### PR TITLE
make map height consistent across different resolutions

### DIFF
--- a/next-project/arctic-well/styles/Map.module.css
+++ b/next-project/arctic-well/styles/Map.module.css
@@ -1,10 +1,9 @@
 .map_container {
   width: 100%;
-  height: 90%;
+  height: 100%;
 }
 
-
-.location_container{
+.location_container {
   position: absolute;
   height: 50px;
   width: 50px;
@@ -15,9 +14,7 @@
   z-index: 10;
 }
 
-
-
-.centerBtn{
+.centerBtn {
   width: 50px;
   height: 50px;
   cursor: pointer;


### PR DESCRIPTION
Removed a hacky workaround that wasn't necessary any more. The map view used to look incredibly ugly on my tablet. Hopefully this fixes that issue